### PR TITLE
Fix version range comparison

### DIFF
--- a/src/main/java/ca/solostudios/strata/version/Version.java
+++ b/src/main/java/ca/solostudios/strata/version/Version.java
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file Version.java is part of Strata
- * Last modified on 24-09-2021 10:36 p.m.
+ * Last modified on 28-11-2021 11:54 a.m.
  *
  * MIT License
  *
@@ -68,18 +68,6 @@ public final class Version implements Comparable<Version>, Formattable {
         this.buildMetadata = buildMetadata;
     }
     
-    @Override
-    public int compareTo(@NotNull Version o) {
-        int normalVersionComparison = coreVersion.compareTo(o.coreVersion);
-        return normalVersionComparison != 0 ? normalVersionComparison : preRelease.compareTo(o.preRelease);
-    }
-    
-    @Override
-    @Contract(pure = true)
-    public String toString() {
-        return String.format("Version{normalVersion=%s, preRelease=%s, buildMetadata=%s}", coreVersion, preRelease, buildMetadata);
-    }
-    
     /**
      * The major version.
      *
@@ -114,6 +102,17 @@ public final class Version implements Comparable<Version>, Formattable {
     }
     
     /**
+     * The core version.
+     *
+     * @return The core version.
+     */
+    @NotNull
+    @Contract(pure = true)
+    public CoreVersion getCoreVersion() {
+        return coreVersion;
+    }
+    
+    /**
      * The pre-release version.
      *
      * @return The pre-release version.
@@ -135,10 +134,10 @@ public final class Version implements Comparable<Version>, Formattable {
         return buildMetadata;
     }
     
-    @NotNull
     @Override
-    public String getFormatted() {
-        return String.format("%s%s%s", coreVersion.getFormatted(), preRelease.getFormatted(), buildMetadata.getFormatted());
+    @Contract(pure = true)
+    public String toString() {
+        return String.format("Version{normalVersion=%s, preRelease=%s, buildMetadata=%s}", coreVersion, preRelease, buildMetadata);
     }
     
     @Override
@@ -165,5 +164,17 @@ public final class Version implements Comparable<Version>, Formattable {
         result = 31 * result + preRelease.hashCode();
         result = 31 * result + buildMetadata.hashCode();
         return result;
+    }
+    
+    @Override
+    public int compareTo(@NotNull Version o) {
+        int normalVersionComparison = coreVersion.compareTo(o.coreVersion);
+        return normalVersionComparison != 0 ? normalVersionComparison : preRelease.compareTo(o.preRelease);
+    }
+    
+    @NotNull
+    @Override
+    public String getFormatted() {
+        return String.format("%s%s%s", coreVersion.getFormatted(), preRelease.getFormatted(), buildMetadata.getFormatted());
     }
 }

--- a/src/main/java/ca/solostudios/strata/version/VersionRange.java
+++ b/src/main/java/ca/solostudios/strata/version/VersionRange.java
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file VersionRange.java is part of Strata
- * Last modified on 28-11-2021 11:54 a.m.
+ * Last modified on 28-11-2021 11:56 a.m.
  *
  * MIT License
  *
@@ -143,18 +143,18 @@ public final class VersionRange implements Formattable {
     public boolean isSatisfiedBy(Version version) {
         if (startVersion != null) {
             if (startInclusive) {
-                if (0 < startVersion.compareTo(version))
+                if (0 < startVersion.getCoreVersion().compareTo(version.getCoreVersion()))
                     return false;
             } else {
-                if (0 <= startVersion.compareTo(version))
+                if (0 <= startVersion.getCoreVersion().compareTo(version.getCoreVersion()))
                     return false;
             }
         }
         if (endVersion != null) {
             if (endInclusive) {
-                return 0 <= endVersion.compareTo(version);
+                return 0 <= endVersion.getCoreVersion().compareTo(version.getCoreVersion());
             } else {
-                return 0 < endVersion.compareTo(version);
+                return 0 < endVersion.getCoreVersion().compareTo(version.getCoreVersion());
             }
         }
     

--- a/src/test/java/ca/solostudios/strata/VersionRangeParserTest.java
+++ b/src/test/java/ca/solostudios/strata/VersionRangeParserTest.java
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file VersionRangeParserTest.java is part of Strata
- * Last modified on 24-09-2021 07:19 p.m.
+ * Last modified on 28-11-2021 11:54 a.m.
  *
  * MIT License
  *
@@ -152,5 +152,11 @@ class VersionRangeParserTest {
         assertTrue(majorRange.isSatisfiedBy("1.2.3"));
         assertTrue(majorRange.isSatisfiedBy("9999.9999.9999"));
         assertTrue(majorRange.isSatisfiedBy("999999999999999999999999999.999999999999999999999999999.999999999999999999999999999"));
+    }
+    
+    @Test
+    void testMetadata() throws ParseException {
+        VersionRange range = parseVersionRange("0.1.+");
+        assertTrue(range.isSatisfiedBy("0.1.0-BETA"));
     }
 }


### PR DESCRIPTION
Alternative to #3.
This exposes `CoreVersion` in `Version` instead of a `compareToCore` method.

Fixes #4 